### PR TITLE
NODE-446 WIP

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ connect.GridStore = require('./lib/gridfs/grid_store');
 connect.Chunk = require('./lib/gridfs/chunk');
 connect.Logger = core.Logger;
 connect.Cursor = require('./lib/cursor');
-connect.GridFSBucket = require('./lib/gridfs-stream').GridFSBucket;
+connect.GridFSBucket = require('./lib/gridfs-stream');
 
 // BSON types exported
 connect.Binary = core.BSON.Binary;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ connect.GridStore = require('./lib/gridfs/grid_store');
 connect.Chunk = require('./lib/gridfs/chunk');
 connect.Logger = core.Logger;
 connect.Cursor = require('./lib/cursor');
+connect.GridFSBucket = require('./lib/gridfs-stream').GridFSBucket;
 
 // BSON types exported
 connect.Binary = core.BSON.Binary;

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -17,7 +17,7 @@ module.exports = GridFSBucketReadStream;
 
 function GridFSBucketReadStream(chunks, files, id) {
   var _this = this;
-  this.cursor = chunks.find({ files_id: id }).sort({ n: 1 });
+  this.cursor = chunks.find({ files_id: id }).sort({ n: 1, _id: 1 });
   this.expected = 0;
 
   stream.Readable.call(this);
@@ -25,6 +25,10 @@ function GridFSBucketReadStream(chunks, files, id) {
   files.findOne({ _id: id }, function(error, doc) {
     if (error) {
       return _this.__handleError(error);
+    }
+    if (!doc) {
+      var errmsg = 'FileNotFound: file ' + id.toString() + ' was not found';
+      return _this.__handleError(new Error(errmsg));
     }
     _this.file = doc;
     _this.bytesRemaining = doc.length;
@@ -61,21 +65,36 @@ GridFSBucketReadStream.prototype.doRead = function() {
       return _this.__handleError(error);
     }
     if (!doc) {
-      return _this.emit('end');
+      return _this.push(null);
     }
 
     var expectedN = _this.expected++;
     var expectedLength = Math.min(_this.file.chunkSize, _this.bytesRemaining);
-    if (doc.n !== expectedN) {
-      var errmsg = 'Got unexpected n: ' + doc.n + ', expected: ' + expectedN;
+    if (doc.n > expectedN) {
+      var errmsg = 'ChunkIsMissing: Got unexpected n: ' + doc.n +
+        ', expected: ' + expectedN;
+      return _this.__handleError(new Error(errmsg));
+    }
+    if (doc.n < expectedN) {
+      var errmsg = 'ExtraChunk: Got unexpected n: ' + doc.n +
+        ', expected: ' + expectedN;
       return _this.__handleError(new Error(errmsg));
     }
     if (doc.data.length() !== expectedLength) {
-      var errmsg = 'Got unexpected length: ' + doc.data.length() +
-        ', expected: ' + expectedLength;
+      if (_this.bytesRemaining <= 0) {
+        var errmsg = 'ExtraChunk: Got unexpected n: ' + doc.n;
+        return _this.__handleError(new Error(errmsg));
+      }
+      var errmsg = 'ChunkIsWrongSize: Got unexpected length: ' +
+        doc.data.length() + ', expected: ' + expectedLength;
       return _this.__handleError(new Error(errmsg));
     }
 
+    _this.bytesRemaining -= doc.data.length();
+
+    if (doc.data.buffer.length === 0) {
+      return _this.push(null);
+    }
     _this.push(doc.data.buffer);
   });
 };

--- a/lib/gridfs-stream/download.js
+++ b/lib/gridfs-stream/download.js
@@ -1,0 +1,81 @@
+var shallowClone = require('../utils').shallowClone;
+var stream = require('stream');
+var util = require('util');
+
+module.exports = GridFSBucketReadStream;
+
+/**
+ * A readable stream that enables you to read buffers from GridFS.
+ *
+ * Do not instantiate this class directly. Use `openDownloadStream()` instead.
+ *
+ * @class
+ * @param {Collection} chunks Handle for chunks collection
+ * @param {Collection} files Handle for files collection
+ * @param {ObjectId} id The id of the file in the files collection
+ */
+
+function GridFSBucketReadStream(chunks, files, id) {
+  var _this = this;
+  this.cursor = chunks.find({ files_id: id }).sort({ n: 1 });
+  this.expected = 0;
+
+  stream.Readable.call(this);
+
+  files.findOne({ _id: id }, function(error, doc) {
+    if (error) {
+      return _this.__handleError(error);
+    }
+    _this.file = doc;
+    _this.bytesRemaining = doc.length;
+    _this.emit('file', doc);
+  });
+}
+
+util.inherits(GridFSBucketReadStream, stream.Readable);
+
+GridFSBucketReadStream.prototype.__handleError = function(error) {
+  this.emit('error', error);
+};
+
+GridFSBucketReadStream.prototype.waitForFile = function(callback) {
+  if (this.file) {
+    return callback();
+  }
+  this.once('file', function() {
+    callback();
+  });
+};
+
+GridFSBucketReadStream.prototype._read = function() {
+  var _this = this;
+  this.waitForFile(function() {
+    _this.doRead();
+  });
+};
+
+GridFSBucketReadStream.prototype.doRead = function() {
+  var _this = this;
+  this.cursor.next(function(error, doc) {
+    if (error) {
+      return _this.__handleError(error);
+    }
+    if (!doc) {
+      return _this.emit('end');
+    }
+
+    var expectedN = _this.expected++;
+    var expectedLength = Math.min(_this.file.chunkSize, _this.bytesRemaining);
+    if (doc.n !== expectedN) {
+      var errmsg = 'Got unexpected n: ' + doc.n + ', expected: ' + expectedN;
+      return _this.__handleError(new Error(errmsg));
+    }
+    if (doc.data.length() !== expectedLength) {
+      var errmsg = 'Got unexpected length: ' + doc.data.length() +
+        ', expected: ' + expectedLength;
+      return _this.__handleError(new Error(errmsg));
+    }
+
+    _this.push(doc.data.buffer);
+  });
+};

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -1,0 +1,171 @@
+var core = require('mongodb-core');
+var crypto = require('crypto');
+var Emitter = require('events').EventEmitter;
+var shallowClone = require('../utils').shallowClone;
+
+var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
+  bucketName: 'fs',
+  chunkSizeBytes: 255 * 1024
+};
+
+exports.GridFSBucket = GridFSBucket;
+
+function GridFSBucket(db, options) {
+  if (options && typeof options === 'object') {
+    options = shallowClone(options);
+    var keys = Object.keys(DEFAULT_GRIDFS_BUCKET_OPTIONS);
+    for (var i = 0; i < keys.length; ++i) {
+      if (!options[keys[i]]) {
+        options[keys[i]] = DEFAULT_GRIDFS_BUCKET_OPTIONS[keys[i]];
+      }
+    }
+  } else {
+    options = DEFAULT_GRIDFS_BUCKET_OPTIONS;
+  }
+
+  this.s = {
+    db: db,
+    options: options,
+    _chunksCollection: db.collection(options.bucketName + '.chunks'),
+    _filesCollection: db.collection(options.bucketName + '.files')
+  };
+};
+
+GridFSBucket.prototype = new Emitter();
+
+GridFSBucket.prototype.uploadFromStream = function(filename, source, options) {
+  options = options || {};
+
+  var _id = core.BSON.ObjectId();
+  var _this = this;
+  var chunkSizeBytes = options.chunkSizeBytes || this.s.options.chunkSizeBytes;
+  var bufToStore = new Buffer(chunkSizeBytes);
+  var length = 0;
+  var md5 = crypto.createHash('md5');
+  var n = 0;
+  var pos = 0;
+  var state = {
+    streamEnd: false,
+    outstandingRequests: 0,
+    errored: false
+  };
+
+  var errorHandler = function(error) {
+    if (state.errored) {
+      return;
+    }
+    _this.emit('error', error);
+  };
+
+  var checkDone = function() {
+    if (state.streamEnd && state.outstandingRequests === 0 && !state.errored) {
+      var filesDoc = createFilesDoc(_id, length, chunkSizeBytes,
+        md5.digest('hex'), filename, options.contentType, options.aliases,
+        options.metadata);
+
+      _this.s._filesCollection.insert(filesDoc, function(error) {
+        if (error) {
+          return errorHandler(error);
+        }
+        _this.emit('done', filename);
+      });
+    }
+  };
+
+  source.on('data', function(inputBuf) {
+    length += inputBuf.length;
+
+    // Input is small enough to fit in our buffer
+    if (pos + inputBuf.length < chunkSizeBytes) {
+      inputBuf.copy(bufToStore, pos);
+      pos += inputBuf.length;
+
+      return;
+    }
+
+    // Otherwise, buffer is full, so store it in the chunks collection
+    inputBuf.copy(bufToStore, pos, 0, chunkSizeBytes - pos);
+    md5.update(bufToStore);
+    var doc = createChunkDoc(_id, n, bufToStore);
+    ++state.outstandingRequests;
+    _this.s._chunksCollection.insert(doc, function(error) {
+      if (error) {
+        return errorHandler(error);
+      }
+      --state.outstandingRequests;
+      checkDone();
+    });
+
+    // Copy any leftover bytes from old buffer
+    inputBuf.copy(bufToStore, 0, chunkSizeBytes - pos);
+
+    // Re-use the old buffer and increment counter
+    pos = inputBuf.length - (chunkSizeBytes - pos);
+    ++n;
+  });
+
+  source.on('error', function(error) {
+    errorHandler(error);
+  });
+
+  source.on('end', function() {
+    state.streamEnd = true;
+
+    // Buffer is empty, so don't bother to insert
+    if (pos === 0) {
+      return checkDone();
+    }
+
+    ++state.outstandingRequests;
+    // Create a new buffer to make sure the buffer isn't bigger than it needs
+    // to be.
+    var remnant = new Buffer(pos);
+    bufToStore.copy(remnant, 0, 0, pos);
+    md5.update(remnant);
+    var doc = createChunkDoc(_id, n, remnant);
+    _this.s._chunksCollection.insert(doc, function(error) {
+      if (error) {
+        return errorHandler(error);
+      }
+      --state.outstandingRequests;
+      checkDone();
+    });
+  });
+
+  return _id;
+};
+
+function createChunkDoc(filesId, n, data) {
+  return {
+    _id: core.BSON.ObjectId(),
+    files_id: filesId,
+    n: n,
+    data: data
+  };
+}
+
+function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
+  aliases, metadata) {
+  var ret = {
+    _id: _id,
+    length: length,
+    chunkSize: chunkSize,
+    uploadDate: new Date(),
+    md5: md5,
+    filename: filename
+  };
+
+  if (contentType) {
+    ret.contentType = contentType;
+  }
+
+  if (aliases) {
+    ret.aliases = aliases;
+  }
+
+  if (metadata) {
+    ret.metadata = metadata;
+  }
+
+  return ret;
+}

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -1,3 +1,4 @@
+var GridFSBucketReadStream = require('./download');
 var GridFSBucketWriteStream = require('./upload');
 var shallowClone = require('../utils').shallowClone;
 
@@ -38,7 +39,8 @@ function GridFSBucket(db, options) {
 
 /**
  * Returns a writable stream (GridFSBucketWriteStream) for writing
- * buffers to GridFS.
+ * buffers to GridFS. The stream's 'id' property contains the resulting
+ * file's id.
  * @method
  * @param {string} filename The value of the 'filename' key in the files doc
  * @param {object} [options=null] Optional settings.
@@ -55,4 +57,16 @@ GridFSBucket.prototype.openUploadStream = function(filename, options) {
   }
   return new GridFSBucketWriteStream(this.s._chunksCollection,
     this.s._filesCollection, filename, options);
+};
+
+/**
+ * Returns a readable stream (GridFSBucketReadStream) for streaming file
+ * data from GridFS.
+ * @method
+ * @param {ObjectId} id The id of the file doc
+ */
+
+GridFSBucket.prototype.openDownloadStream = function(id) {
+  return new GridFSBucketReadStream(this.s._chunksCollection,
+    this.s._filesCollection, id);
 };

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -14,6 +14,7 @@ module.exports = GridFSBucket;
  * @method
  * @param {Db} db A db handle
  * @param {object} [options=null] Optional settings.
+ * @return {GridFSBucket}
  */
 
 function GridFSBucket(db, options) {
@@ -44,6 +45,7 @@ function GridFSBucket(db, options) {
  * @method
  * @param {string} filename The value of the 'filename' key in the files doc
  * @param {object} [options=null] Optional settings.
+ * @return {GridFSBucketWriteStream}
  */
 
 GridFSBucket.prototype.openUploadStream = function(filename, options) {
@@ -64,6 +66,7 @@ GridFSBucket.prototype.openUploadStream = function(filename, options) {
  * data from GridFS.
  * @method
  * @param {ObjectId} id The id of the file doc
+ * @return {GridFSBucketReadStream}
  */
 
 GridFSBucket.prototype.openDownloadStream = function(id) {
@@ -99,4 +102,40 @@ GridFSBucket.prototype.delete = function(id, callback) {
       callback();
     });
   });
+};
+
+/**
+ * Convenience wrapper around find on the files collection
+ * @method
+ * @param {Object} filter
+ * @param {Object} options
+ * @return {Cursor}
+ */
+
+GridFSBucket.prototype.find = function(filter, options) {
+  filter = filter || {};
+  options = options || {};
+
+  var cursor = this.s._filesCollection.find(filter);
+
+  if (options.batchSize != null) {
+    cursor.batchSize(options.batchSize);
+  }
+  if (options.limit != null) {
+    cursor.batchSize(options.limit);
+  }
+  if (options.maxTimeMS != null) {
+    cursor.maxTimeMS(options.maxTimeMS);
+  }
+  if (options.noCursorTimeout != null) {
+    cursor.addCursorFlag('noCursorTimeout', true);
+  }
+  if (options.skip != null) {
+    cursor.skip(options.skip);
+  }
+  if (options.sort != null) {
+    cursor.sort(options.sort);
+  }
+
+  return cursor;
 };

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -80,13 +80,20 @@ GridFSBucket.prototype.openDownloadStream = function(id) {
 
 GridFSBucket.prototype.delete = function(id, callback) {
   var _this = this;
-  this.s._filesCollection.removeOne({ _id: id }, function(error) {
+  this.s._filesCollection.deleteOne({ _id: id }, function(error, res) {
     if (error) {
       return callback(error);
     }
-    _this.s._chunksCollection.removeMany({ files_id: id }, function(error) {
+
+    _this.s._chunksCollection.deleteMany({ files_id: id }, function(error) {
       if (error) {
         return callback(error);
+      }
+
+      // Delete orphaned chunks before returning FileNotFound
+      if (!res.result.n) {
+        var errmsg = 'FileNotFound: no file with id ' + id + ' found';
+        return callback(new Error(errmsg));
       }
 
       callback();

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -70,3 +70,26 @@ GridFSBucket.prototype.openDownloadStream = function(id) {
   return new GridFSBucketReadStream(this.s._chunksCollection,
     this.s._filesCollection, id);
 };
+
+/**
+ * Deletes a file with the given id
+ * @method
+ * @param {ObjectId} id The id of the file doc
+ * @param {Function} callback
+ */
+
+GridFSBucket.prototype.delete = function(id, callback) {
+  var _this = this;
+  this.s._filesCollection.removeOne({ _id: id }, function(error) {
+    if (error) {
+      return callback(error);
+    }
+    _this.s._chunksCollection.removeMany({ files_id: id }, function(error) {
+      if (error) {
+        return callback(error);
+      }
+
+      callback();
+    });
+  });
+};

--- a/lib/gridfs-stream/index.js
+++ b/lib/gridfs-stream/index.js
@@ -1,6 +1,4 @@
-var core = require('mongodb-core');
-var crypto = require('crypto');
-var Emitter = require('events').EventEmitter;
+var GridFSBucketWriteStream = require('./upload');
 var shallowClone = require('../utils').shallowClone;
 
 var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
@@ -8,7 +6,14 @@ var DEFAULT_GRIDFS_BUCKET_OPTIONS = {
   chunkSizeBytes: 255 * 1024
 };
 
-exports.GridFSBucket = GridFSBucket;
+module.exports = GridFSBucket;
+
+/**
+ * Constructor for a streaming GridFS interface
+ * @method
+ * @param {Db} db A db handle
+ * @param {object} [options=null] Optional settings.
+ */
 
 function GridFSBucket(db, options) {
   if (options && typeof options === 'object') {
@@ -31,141 +36,23 @@ function GridFSBucket(db, options) {
   };
 };
 
-GridFSBucket.prototype = new Emitter();
+/**
+ * Returns a writable stream (GridFSBucketWriteStream) for writing
+ * buffers to GridFS.
+ * @method
+ * @param {string} filename The value of the 'filename' key in the files doc
+ * @param {object} [options=null] Optional settings.
+ */
 
-GridFSBucket.prototype.uploadFromStream = function(filename, source, options) {
-  options = options || {};
-
-  var _id = core.BSON.ObjectId();
-  var _this = this;
-  var chunkSizeBytes = options.chunkSizeBytes || this.s.options.chunkSizeBytes;
-  var bufToStore = new Buffer(chunkSizeBytes);
-  var length = 0;
-  var md5 = crypto.createHash('md5');
-  var n = 0;
-  var pos = 0;
-  var state = {
-    streamEnd: false,
-    outstandingRequests: 0,
-    errored: false
-  };
-
-  var errorHandler = function(error) {
-    if (state.errored) {
-      return;
-    }
-    _this.emit('error', error);
-  };
-
-  var checkDone = function() {
-    if (state.streamEnd && state.outstandingRequests === 0 && !state.errored) {
-      var filesDoc = createFilesDoc(_id, length, chunkSizeBytes,
-        md5.digest('hex'), filename, options.contentType, options.aliases,
-        options.metadata);
-
-      _this.s._filesCollection.insert(filesDoc, function(error) {
-        if (error) {
-          return errorHandler(error);
-        }
-        _this.emit('done', filename);
-      });
-    }
-  };
-
-  source.on('data', function(inputBuf) {
-    length += inputBuf.length;
-
-    // Input is small enough to fit in our buffer
-    if (pos + inputBuf.length < chunkSizeBytes) {
-      inputBuf.copy(bufToStore, pos);
-      pos += inputBuf.length;
-
-      return;
-    }
-
-    // Otherwise, buffer is full, so store it in the chunks collection
-    inputBuf.copy(bufToStore, pos, 0, chunkSizeBytes - pos);
-    md5.update(bufToStore);
-    var doc = createChunkDoc(_id, n, bufToStore);
-    ++state.outstandingRequests;
-    _this.s._chunksCollection.insert(doc, function(error) {
-      if (error) {
-        return errorHandler(error);
-      }
-      --state.outstandingRequests;
-      checkDone();
-    });
-
-    // Copy any leftover bytes from old buffer
-    inputBuf.copy(bufToStore, 0, chunkSizeBytes - pos);
-
-    // Re-use the old buffer and increment counter
-    pos = inputBuf.length - (chunkSizeBytes - pos);
-    ++n;
-  });
-
-  source.on('error', function(error) {
-    errorHandler(error);
-  });
-
-  source.on('end', function() {
-    state.streamEnd = true;
-
-    // Buffer is empty, so don't bother to insert
-    if (pos === 0) {
-      return checkDone();
-    }
-
-    ++state.outstandingRequests;
-    // Create a new buffer to make sure the buffer isn't bigger than it needs
-    // to be.
-    var remnant = new Buffer(pos);
-    bufToStore.copy(remnant, 0, 0, pos);
-    md5.update(remnant);
-    var doc = createChunkDoc(_id, n, remnant);
-    _this.s._chunksCollection.insert(doc, function(error) {
-      if (error) {
-        return errorHandler(error);
-      }
-      --state.outstandingRequests;
-      checkDone();
-    });
-  });
-
-  return _id;
+GridFSBucket.prototype.openUploadStream = function(filename, options) {
+  if (options) {
+    options = shallowClone(options);
+  } else {
+    options = {};
+  }
+  if (!options.chunkSizeBytes) {
+    options.chunkSizeBytes = this.s.options.chunkSizeBytes;
+  }
+  return new GridFSBucketWriteStream(this.s._chunksCollection,
+    this.s._filesCollection, filename, options);
 };
-
-function createChunkDoc(filesId, n, data) {
-  return {
-    _id: core.BSON.ObjectId(),
-    files_id: filesId,
-    n: n,
-    data: data
-  };
-}
-
-function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
-  aliases, metadata) {
-  var ret = {
-    _id: _id,
-    length: length,
-    chunkSize: chunkSize,
-    uploadDate: new Date(),
-    md5: md5,
-    filename: filename
-  };
-
-  if (contentType) {
-    ret.contentType = contentType;
-  }
-
-  if (aliases) {
-    ret.aliases = aliases;
-  }
-
-  if (metadata) {
-    ret.metadata = metadata;
-  }
-
-  return ret;
-}

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -200,15 +200,6 @@ GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
 };
 
 /**
- * Delete all
- *
- * @method
- * @param {Buffer} chunk Buffer to write
- * @param {String} encoding Optional encoding for the buffer
- * @param {Function} callback Function to call when all files and chunks have been persisted to MongoDB
- */
-
-/**
  * @ignore
  */
 

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -1,0 +1,252 @@
+var core = require('mongodb-core');
+var crypto = require('crypto');
+var shallowClone = require('../utils').shallowClone;
+var stream = require('stream');
+var util = require('util');
+
+module.exports = GridFSBucketWriteStream;
+
+/**
+ * A writable stream that enables you to write buffers to GridFS.
+ *
+ * Do not instantiate this class directly. Use `openUploadStream()` instead.
+ *
+ * @class
+ * @param {Collection} chunks Handle for chunks collection
+ * @param {Collection} files Handle for files collection
+ * @param {string} filename The value of the 'filename' key in the files doc
+ * @param {object} [options=null] Optional settings.
+ */
+
+function GridFSBucketWriteStream(chunks, files, filename, options) {
+  this.chunks = chunks;
+  this.files = files;
+  this.filename = filename;
+  this.options = options;
+
+  this.id = core.BSON.ObjectId();
+  this.chunkSizeBytes = this.options.chunkSizeBytes;
+  this.bufToStore = new Buffer(this.chunkSizeBytes);
+  this.length = 0;
+  this.md5 = crypto.createHash('md5');
+  this.n = 0;
+  this.pos = 0;
+  this.state = {
+    streamEnd: false,
+    outstandingRequests: 0,
+    errored: false
+  };
+}
+
+util.inherits(GridFSBucketWriteStream, stream.Writable);
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.__handleError = function(error, callback) {
+  if (this.state.errored) {
+    return;
+  }
+  this.state.errored = true;
+  if (callback) {
+    return callback(error);
+  }
+  this.emit('error', error);
+};
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.__checkDone = function(callback) {
+  var _this = this;
+  if (this.state.streamEnd &&
+      this.state.outstandingRequests === 0 &&
+      !this.state.errored) {
+    var filesDoc = createFilesDoc(this.id, this.length, this.chunkSizeBytes,
+      this.md5.digest('hex'), this.filename, this.options.contentType,
+      this.options.aliases, this.options.metadata);
+
+    this.files.insert(filesDoc, function(error) {
+      if (error) {
+        return errorHandler(error, callback);
+      }
+      _this.emit('finish', filesDoc);
+    });
+
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.__writeRemnant = function(callback) {
+  var _this = this;
+  // Buffer is empty, so don't bother to insert
+  if (this.pos === 0) {
+    return this.__checkDone(callback);
+  }
+
+  ++this.state.outstandingRequests;
+
+  // Create a new buffer to make sure the buffer isn't bigger than it needs
+  // to be.
+  var remnant = new Buffer(this.pos);
+  this.bufToStore.copy(remnant, 0, 0, this.pos);
+  this.md5.update(remnant);
+  var doc = createChunkDoc(this.id, this.n, remnant);
+  this.chunks.insert(doc, function(error) {
+    if (error) {
+      return _this.__errorHandler(error);
+    }
+    --_this.state.outstandingRequests;
+    _this.__checkDone();
+  });
+};
+
+/**
+ * Write a buffer to the stream.
+ *
+ * @method
+ * @param {Buffer} chunk Buffer to write
+ * @param {String} encoding Optional encoding for the buffer
+ * @param {Function} callback Function to call when the chunk was added to the buffer, or if the entire chunk was persisted to MongoDB if this chunk caused a flush.
+ * @return {Boolean} False if this write required flushing a chunk to MongoDB. True otherwise.
+ */
+
+GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
+  var _this = this;
+  var inputBuf = (Buffer.isBuffer(chunk)) ?
+    chunk : new Buffer(chunk, encoding);
+
+  this.length += inputBuf.length;
+
+  // Input is small enough to fit in our buffer
+  if (this.pos + inputBuf.length < this.chunkSizeBytes) {
+    inputBuf.copy(this.bufToStore, this.pos);
+    this.pos += inputBuf.length;
+
+    callback && callback();
+
+    // Note that we reverse the typical semantics of write's return value
+    // to be compatible with node's `.pipe()` function.
+    // True means client can keep writing.
+    return true;
+  }
+
+  // Otherwise, buffer is full, so store it in the chunks collection
+  inputBuf.copy(this.bufToStore, this.pos, 0, this.chunkSizeBytes - this.pos);
+  this.md5.update(this.bufToStore);
+  var doc = createChunkDoc(this.id, this.n, this.bufToStore);
+  ++this.state.outstandingRequests;
+  this.chunks.insert(doc, function(error) {
+    if (error) {
+      return this.__errorHandler(error);
+    }
+    --_this.state.outstandingRequests;
+    _this.emit('drain', doc);
+    callback && callback();
+    _this.__checkDone();
+  });
+
+  // Copy any leftover bytes from old buffer
+  inputBuf.copy(this.bufToStore, 0, this.chunkSizeBytes - this.pos);
+
+  // Re-use the old buffer and increment counter
+  this.pos = inputBuf.length - (this.chunkSizeBytes - this.pos);
+  ++this.n;
+
+  // Note that we reverse the typical semantics of write's return value
+  // to be compatible with node's `.pipe()` function.
+  // False means the client should wait for the 'drain' event.
+  return false;
+};
+
+/**
+ * Tells the stream that no more data will be coming in. The stream will
+ * persist the remaining data to MongoDB, write the files document, and
+ * then emit a 'finish' event.
+ *
+ * @method
+ * @param {Buffer} chunk Buffer to write
+ * @param {String} encoding Optional encoding for the buffer
+ * @param {Function} callback Function to call when all files and chunks have been persisted to MongoDB
+ */
+
+GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
+  this.state.streamEnd = true;
+
+  if (callback) {
+    this.once('finish', callback);
+  }
+
+  if (!chunk) {
+    this.__writeRemnant();
+    return;
+  }
+
+  var _this = this;
+  var inputBuf = (Buffer.isBuffer(chunk)) ?
+    chunk : new Buffer(chunk, encoding);
+
+  this.write(chunk, encoding, function() {
+    this.__writeRemnant();
+  });
+};
+
+/**
+ * Delete all
+ *
+ * @method
+ * @param {Buffer} chunk Buffer to write
+ * @param {String} encoding Optional encoding for the buffer
+ * @param {Function} callback Function to call when all files and chunks have been persisted to MongoDB
+ */
+
+/**
+ * @ignore
+ */
+
+function createChunkDoc(filesId, n, data) {
+  return {
+    _id: core.BSON.ObjectId(),
+    files_id: filesId,
+    n: n,
+    data: data
+  };
+}
+
+/**
+ * @ignore
+ */
+
+function createFilesDoc(_id, length, chunkSize, md5, filename, contentType,
+  aliases, metadata) {
+  var ret = {
+    _id: _id,
+    length: length,
+    chunkSize: chunkSize,
+    uploadDate: new Date(),
+    md5: md5,
+    filename: filename
+  };
+
+  if (contentType) {
+    ret.contentType = contentType;
+  }
+
+  if (aliases) {
+    ret.aliases = aliases;
+  }
+
+  if (metadata) {
+    ret.metadata = metadata;
+  }
+
+  return ret;
+}

--- a/lib/gridfs-stream/upload.js
+++ b/lib/gridfs-stream/upload.js
@@ -4,6 +4,8 @@ var shallowClone = require('../utils').shallowClone;
 var stream = require('stream');
 var util = require('util');
 
+var ERROR_NAMESPACE_NOT_FOUND = 26;
+
 module.exports = GridFSBucketWriteStream;
 
 /**
@@ -32,13 +34,143 @@ function GridFSBucketWriteStream(chunks, files, filename, options) {
   this.n = 0;
   this.pos = 0;
   this.state = {
+    hasCheckedIndexes: false,
     streamEnd: false,
     outstandingRequests: 0,
     errored: false
   };
+
+  var _this = this;
+  this.checkIndexes(function() {
+    _this.state.hasCheckedIndexes = true;
+    _this.emit('index');
+  });
 }
 
 util.inherits(GridFSBucketWriteStream, stream.Writable);
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.checkIndexes = function(callback) {
+  var _this = this;
+
+  this.files.findOne({}, { _id: 1 }, function(error, doc) {
+    if (error) {
+      return callback(error);
+    }
+    if (doc) {
+      return callback();
+    }
+
+    _this.files.listIndexes().toArray(function(error, indexes) {
+      if (error) {
+        // Collection doesn't exist so create index
+        if (error.code === ERROR_NAMESPACE_NOT_FOUND) {
+          var index = { filename: 1, uploadDate: 1 };
+          _this.files.createIndex(index, { background: false }, function(error) {
+            if (error) {
+              return callback(error);
+            }
+
+            _this.checkChunksIndex(callback);
+          });
+          return;
+        }
+        return callback(error);
+      }
+
+      var hasFileIndex = false;
+      indexes.forEach(function(index) {
+        var keys = Object.keys(index.key);
+        if (keys.length === 2 && index.key.filename === 1 &&
+            index.key.uploadDate === 1) {
+          hasFileIndex = true;
+        }
+      });
+
+      if (hasFileIndex) {
+        _this.checkChunksIndex(callback);
+      } else {
+        var index = { filename: 1, uploadDate: 1 };
+        _this.files.createIndex(index, { background: false }, function(error) {
+          if (error) {
+            return callback(error);
+          }
+
+          _this.checkChunksIndex(callback);
+        });
+      }
+    });
+  });
+};
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.checkChunksIndex = function(callback) {
+  var _this = this;
+
+  this.chunks.listIndexes().toArray(function(error, indexes) {
+    if (error) {
+      // Collection doesn't exist so create index
+      if (error.code === ERROR_NAMESPACE_NOT_FOUND) {
+        var index = { files_id: 1, n: 1 };
+        _this.chunks.createIndex(index, { background: false }, function(error) {
+          if (error) {
+            return callback(error);
+          }
+
+          callback();
+        });
+        return;
+      }
+      return callback(error);
+    }
+
+    var hasChunksIndex = false;
+    indexes.forEach(function(index) {
+      if (index.key) {
+        var keys = Object.keys(index.key);
+        if (keys.length === 2 && index.key.files_id === 1 &&
+            index.key.n === 1) {
+          hasChunksIndex = true;
+        }
+      }
+    });
+
+    if (hasChunksIndex) {
+      callback();
+    } else {
+      var index = { files_id: 1, n: 1 };
+      _this.chunks.createIndex(index, { background: false }, function(error) {
+        if (error) {
+          return callback(error);
+        }
+
+        callback();
+      });
+    }
+  });
+};
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.__waitForIndexes = function(callback) {
+  if (this.state.hasCheckedIndexes) {
+    return callback();
+  }
+
+  this.once('index', function() {
+    callback();
+  });
+
+  return true;
+};
 
 /**
  * @ignore
@@ -70,7 +202,7 @@ GridFSBucketWriteStream.prototype.__checkDone = function(callback) {
 
     this.files.insert(filesDoc, function(error) {
       if (error) {
-        return errorHandler(error, callback);
+        return _this.__handleError(error, callback);
       }
       _this.emit('finish', filesDoc);
     });
@@ -102,7 +234,7 @@ GridFSBucketWriteStream.prototype.__writeRemnant = function(callback) {
   var doc = createChunkDoc(this.id, this.n, remnant);
   this.chunks.insert(doc, function(error) {
     if (error) {
-      return _this.__errorHandler(error);
+      return _this.__handleError(error);
     }
     --_this.state.outstandingRequests;
     _this.__checkDone();
@@ -120,6 +252,17 @@ GridFSBucketWriteStream.prototype.__writeRemnant = function(callback) {
  */
 
 GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
+  var _this = this;
+  return this.__waitForIndexes(function() {
+    return _this.__doWrite(chunk, encoding, callback);
+  });
+};
+
+/**
+ * @ignore
+ */
+
+GridFSBucketWriteStream.prototype.__doWrite = function(chunk, encoding, callback) {
   var _this = this;
   var inputBuf = (Buffer.isBuffer(chunk)) ?
     chunk : new Buffer(chunk, encoding);
@@ -146,7 +289,7 @@ GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
   ++this.state.outstandingRequests;
   this.chunks.insert(doc, function(error) {
     if (error) {
-      return this.__errorHandler(error);
+      return this.__handleError(error);
     }
     --_this.state.outstandingRequests;
     _this.emit('drain', doc);
@@ -179,6 +322,7 @@ GridFSBucketWriteStream.prototype.write = function(chunk, encoding, callback) {
  */
 
 GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
+  var _this = this;
   this.state.streamEnd = true;
 
   if (callback) {
@@ -186,7 +330,9 @@ GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
   }
 
   if (!chunk) {
-    this.__writeRemnant();
+    this.__waitForIndexes(function() {
+      _this.__writeRemnant();
+    });
     return;
   }
 
@@ -195,7 +341,7 @@ GridFSBucketWriteStream.prototype.end = function(chunk, encoding, callback) {
     chunk : new Buffer(chunk, encoding);
 
   this.write(chunk, encoding, function() {
-    this.__writeRemnant();
+    _this.__writeRemnant();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     , "semver": "4.1.0"
     , "rimraf": "2.2.6"
     , "gleak": "0.5.0"
+    , "mongodb-extended-json": "1.3.0"
     , "mongodb-version-manager": "^0.7.1"
     , "mongodb-tools": "~1.0"
     , "co": "4.5.4"

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -1,0 +1,133 @@
+var core = require('mongodb-core');
+var crypto = require('crypto');
+var fs = require('fs');
+var stream = require('stream');
+
+/**
+ * @ignore
+ */
+exports.shouldUploadFromFileStream = {
+  metadata: { requires: { topology: ['single'] } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var GridFSBucket = configuration.require.GridFSBucket;
+
+    var db = configuration.newDbInstance(configuration.writeConcernMax(),
+      { poolSize:1 });
+    db.open(function(err, db) {
+      var bucket = new GridFSBucket(db);
+      var stream = fs.createReadStream('./LICENSE');
+
+      bucket.on('error', function(error) {
+        test.equal(error, null);
+        test.ok(false);
+      });
+
+      var fileId = bucket.uploadFromStream('test.dat', stream);
+      var license = fs.readFileSync('./LICENSE');
+
+      bucket.once('done', function() {
+        var chunksQuery = db.collection('fs.chunks').find({ files_id: fileId });
+        chunksQuery.toArray(function(error, docs) {
+          test.equal(error, null);
+          test.equal(docs.length, 1);
+          test.equal(docs[0].data.toString('hex'), license.toString('hex'));
+
+          var filesQuery = db.collection('fs.files').find({ _id: fileId });
+          filesQuery.toArray(function(error, docs) {
+            test.equal(error, null);
+            test.equal(docs.length, 1);
+
+            var hash = crypto.createHash('md5');
+            hash.update(license);
+            test.equal(docs[0].md5, hash.digest('hex'));
+            test.done();
+          });
+        });
+      });
+    });
+  }
+};
+
+var UPLOAD_SPEC = require('./specs/gridfs-upload.json');
+
+for (var i = 0; i < UPLOAD_SPEC.tests.length; ++i) {
+  var test = UPLOAD_SPEC.tests[i];
+  (function(testSpec) {
+    exports[testSpec.description] = {
+      metadata: { requires: { topology: ['single'] } },
+
+      test: function(configuration, test) {
+        var GridFSBucket = configuration.require.GridFSBucket;
+
+        var db = configuration.newDbInstance(configuration.writeConcernMax(),
+          { poolSize:1 });
+        db.open(function(err, db) {
+          db.dropDatabase(function(err) {
+            test.equal(err, null);
+
+            var bucket = new GridFSBucket(db, { bucketName: 'expected' });
+            var bufStream = new stream();
+
+            bucket.on('error', function(error) {
+              test.equal(error, null);
+              test.ok(false);
+            });
+
+            var result = bucket.uploadFromStream(testSpec.act.arguments.filename,
+              bufStream, testSpec.act.arguments.options);
+            var buf = new Buffer(testSpec.act.arguments.source.$hex, 'hex');
+            bufStream.emit('data', buf);
+            bufStream.emit('end');
+
+            bucket.once('done', function() {
+              var data = testSpec.assert.data;
+              var num = data.length;
+              data.forEach(function(data) {
+                var collection = data.insert;
+                db.collection(collection).find({}).toArray(function(error, docs) {
+                  test.equal(data.documents.length, docs.length);
+
+                  for (var i = 0; i < docs.length; ++i) {
+                    testResultDoc(test, data.documents[i], docs[i], result);
+                  }
+
+                  if (--num === 0) {
+                    test.done();
+                  }
+                });
+              });
+            });
+          });
+        });
+      }
+    };
+  })(test);
+}
+
+function testResultDoc(test, specDoc, resDoc, result) {
+  var specKeys = Object.keys(specDoc);
+  var resKeys = Object.keys(resDoc);
+
+  test.ok(specKeys.length === resKeys.length);
+
+  for (var i = 0; i < specKeys.length; ++i) {
+    var key = specKeys[i];
+    test.equal(specKeys[i], resKeys[i]);
+    if (specDoc[key] === '*actual') {
+      test.ok(resDoc[key]);
+    } else if (specDoc[key] === '*result') {
+      test.equal(resDoc[key], result.toString());
+    } else if (specDoc[key].$hex) {
+      test.ok(resDoc[key] instanceof core.BSON.Binary);
+      test.equal(resDoc[key].toString('hex'), specDoc[key].$hex);
+    } else {
+      if (typeof specDoc[key] === 'object') {
+        test.deepEqual(specDoc[key], resDoc[key]);
+      } else {
+        test.equal(specDoc[key], resDoc[key]);
+      }
+    }
+  }
+}

--- a/test/functional/gridfs_stream_tests.js
+++ b/test/functional/gridfs_stream_tests.js
@@ -104,6 +104,53 @@ exports.shouldDownloadToUploadStream = {
   }
 };
 
+/**
+ * @ignore
+ */
+exports['Deleting a file'] = {
+  metadata: { requires: { topology: ['single'] } },
+
+  // The actual test we wish to run
+  test: function(configuration, test) {
+    var GridFSBucket = configuration.require.GridFSBucket;
+
+    var db = configuration.newDbInstance(configuration.writeConcernMax(),
+      { poolSize:1 });
+    db.open(function(err, db) {
+      var bucket = new GridFSBucket(db, { bucketName: 'gridfsdownload' });
+      var CHUNKS_COLL = 'gridfsdownload.chunks';
+      var FILES_COLL = 'gridfsdownload.files';
+      var readStream = fs.createReadStream('./LICENSE');
+
+      var uploadStream = bucket.openUploadStream('test.dat');
+
+      var license = fs.readFileSync('./LICENSE');
+      var id = uploadStream.id;
+
+      uploadStream.once('finish', function() {
+        bucket.delete(id, function(error) {
+          test.equal(error, null);
+
+          var chunksQuery = db.collection(CHUNKS_COLL).find({ files_id: id });
+          chunksQuery.toArray(function(error, docs) {
+            test.equal(error, null);
+            test.equal(docs.length, 0);
+
+            var filesQuery = db.collection(FILES_COLL).find({ _id: id });
+            filesQuery.toArray(function(error, docs) {
+              test.equal(error, null);
+              test.equal(docs.length, 0);
+
+              test.done();
+            });
+          });
+        });
+      });
+
+      readStream.pipe(uploadStream);
+    });
+  }
+};
 
 var UPLOAD_SPEC = require('./specs/gridfs-upload.json');
 

--- a/test/functional/specs/gridfs-download.json
+++ b/test/functional/specs/gridfs-download.json
@@ -1,0 +1,564 @@
+{
+  "data": {
+    "files": [
+      {
+        "_id": {
+          "$oid": "000000000000000000000001"
+        },
+        "length": 0,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "d41d8cd98f00b204e9800998ecf8427e",
+        "filename": "length-0",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000002"
+        },
+        "length": 0,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "d41d8cd98f00b204e9800998ecf8427e",
+        "filename": "length-0-with-empty-chunk",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000003"
+        },
+        "length": 2,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "c700ed4fdb1d27055aa3faa2c2432283",
+        "filename": "length-2",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000004"
+        },
+        "length": 8,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "dd254cdc958e53abaa67da9f797125f5",
+        "filename": "length-8",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000005"
+        },
+        "length": 10,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "57d83cd477bfb1ccd975ab33d827a92b",
+        "filename": "length-10",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "length": 12,
+        "chunkSize": 4,
+        "uploadDate": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "md5": "6289ac1db331d1c7677a4b7e123178f9",
+        "filename": "length-12-with-empty-chunk",
+        "contentType": "application/octet-stream",
+        "aliases": [
+
+        ],
+        "metadata": {
+        }
+      }
+    ],
+    "chunks": [
+      {
+        "_id": {
+          "$oid": "000000000000000000000001"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000002"
+        },
+        "n": 0,
+        "data": {
+          "$hex": ""
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000002"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000003"
+        },
+        "n": 0,
+        "data": {
+          "$hex": "1122"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000003"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000004"
+        },
+        "n": 0,
+        "data": {
+          "$hex": "11223344"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000004"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000004"
+        },
+        "n": 1,
+        "data": {
+          "$hex": "55667788"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000005"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000005"
+        },
+        "n": 0,
+        "data": {
+          "$hex": "11223344"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000005"
+        },
+        "n": 1,
+        "data": {
+          "$hex": "55667788"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000007"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000005"
+        },
+        "n": 2,
+        "data": {
+          "$hex": "99aa"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000008"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "n": 0,
+        "data": {
+          "$hex": "11223344"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000009"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "n": 1,
+        "data": {
+          "$hex": "55667788"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000010"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "n": 2,
+        "data": {
+          "$hex": "99aabbcc"
+        }
+      },
+      {
+        "_id": {
+          "$oid": "000000000000000000000011"
+        },
+        "files_id": {
+          "$oid": "000000000000000000000006"
+        },
+        "n": 3,
+        "data": {
+          "$hex": ""
+        }
+      }
+    ]
+  },
+  "tests": [
+    {
+      "description": "Download when length is zero",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000001"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": ""
+        }
+      }
+    },
+    {
+      "description": "Download when length is zero and there is one empty chunk",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000002"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": ""
+        }
+      }
+    },
+    {
+      "description": "Download when there is one chunk",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000003"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": "1122"
+        }
+      }
+    },
+    {
+      "description": "Download when there are two chunks",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000004"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": "1122334455667788"
+        }
+      }
+    },
+    {
+      "description": "Download when there are three chunks",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000005"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": "112233445566778899aa"
+        }
+      }
+    },
+    {
+      "description": "Download when there are three chunks and one extra empty chunk at the end",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000006"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "result": {
+          "$hex": "112233445566778899aabbcc"
+        }
+      }
+    },
+    {
+      "description": "Download when files entry does not exist",
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000000"
+          },
+          "options": {
+          }
+        }
+      },
+      "assert": {
+        "error": "FileNotFound"
+      }
+    },
+    {
+      "description": "Download when an intermediate chunk is missing",
+      "arrange": {
+        "data": [
+          {
+            "delete": "fs.chunks",
+            "deletes": [
+              {
+                "q": {
+                  "files_id": {
+                    "$oid": "000000000000000000000005"
+                  },
+                  "n": 1
+                },
+                "limit": 1
+              }
+            ]
+          }
+        ]
+      },
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000005"
+          }
+        }
+      },
+      "assert": {
+        "error": "ChunkIsMissing"
+      }
+    },
+    {
+      "description": "Download when final chunk is missing",
+      "arrange": {
+        "data": [
+          {
+            "delete": "fs.chunks",
+            "deletes": [
+              {
+                "q": {
+                  "files_id": {
+                    "$oid": "000000000000000000000005"
+                  },
+                  "n": 1
+                },
+                "limit": 1
+              }
+            ]
+          }
+        ]
+      },
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000005"
+          }
+        }
+      },
+      "assert": {
+        "error": "ChunkIsMissing"
+      }
+    },
+    {
+      "description": "Download when there is an extra chunk",
+      "arrange": {
+        "data": [
+          {
+            "insert": "fs.chunks",
+            "documents": [
+              {
+                "_id": {
+                  "$oid": "000000000000000000000012"
+                },
+                "files_id": {
+                  "$oid": "000000000000000000000004"
+                },
+                "n": 2,
+                "data": {
+                  "$hex": "99"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000004"
+          }
+        }
+      },
+      "assert": {
+        "error": "ExtraChunk"
+      }
+    },
+    {
+      "description": "Download when an intermediate chunk is the wrong size",
+      "arrange": {
+        "data": [
+          {
+            "update": "fs.chunks",
+            "updates": [
+              {
+                "q": {
+                  "files_id": {
+                    "$oid": "000000000000000000000005"
+                  },
+                  "n": 1
+                },
+                "u": {
+                  "$set": {
+                    "data": {
+                      "$hex": "556677"
+                    }
+                  }
+                }
+              },
+              {
+                "q": {
+                  "files_id": {
+                    "$oid": "000000000000000000000005"
+                  },
+                  "n": 2
+                },
+                "u": {
+                  "$set": {
+                    "data": {
+                      "$hex": "8899aa"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000005"
+          }
+        }
+      },
+      "assert": {
+        "error": "ChunkIsWrongSize"
+      }
+    },
+    {
+      "description": "Download when final chunk is the wrong size",
+      "arrange": {
+        "data": [
+          {
+            "update": "fs.chunks",
+            "updates": [
+              {
+                "q": {
+                  "files_id": {
+                    "$oid": "000000000000000000000005"
+                  },
+                  "n": 2
+                },
+                "u": {
+                  "$set": {
+                    "data": {
+                      "$hex": "99"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "act": {
+        "operation": "download",
+        "arguments": {
+          "id": {
+            "$oid": "000000000000000000000005"
+          }
+        }
+      },
+      "assert": {
+        "error": "ChunkIsWrongSize"
+      }
+    }
+  ]
+}

--- a/test/functional/specs/gridfs-upload.json
+++ b/test/functional/specs/gridfs-upload.json
@@ -1,0 +1,391 @@
+{
+  "data": {
+    "files": [
+
+    ],
+    "chunks": [
+
+    ]
+  },
+  "tests": [
+    {
+      "description": "Upload when length is 0",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": ""
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 0,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "d41d8cd98f00b204e9800998ecf8427e",
+                "filename": "filename"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when length is 1",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "11"
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 1,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "47ed733b8d10be225eceba344d533586",
+                "filename": "filename"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when length is 3",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "112233"
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 3,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "bafae3a174ab91fc70db7a6aa50f4f52",
+                "filename": "filename"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "112233"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when length is 4",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "11223344"
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 4,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "7e7c77cff5705d1f7574a25ef6662117",
+                "filename": "filename"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11223344"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when length is 5",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "1122334455"
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 5,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "283d4fea5dded59cf837d3047328f5af",
+                "filename": "filename"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11223344"
+                }
+              },
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 1,
+                "data": {
+                  "$hex": "55"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when length is 8",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "1122334455667788"
+          },
+          "options": {
+            "chunkSizeBytes": 4
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 8,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "dd254cdc958e53abaa67da9f797125f5",
+                "filename": "filename"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11223344"
+                }
+              },
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 1,
+                "data": {
+                  "$hex": "55667788"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when contentType is provided",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "11"
+          },
+          "options": {
+            "chunkSizeBytes": 4,
+            "contentType": "image/jpeg"
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 1,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "47ed733b8d10be225eceba344d533586",
+                "filename": "filename",
+                "contentType": "image/jpeg"
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "description": "Upload when metadata is provided",
+      "act": {
+        "operation": "upload",
+        "arguments": {
+          "filename": "filename",
+          "source": {
+            "$hex": "11"
+          },
+          "options": {
+            "chunkSizeBytes": 4,
+            "metadata": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "assert": {
+        "result": "&result",
+        "data": [
+          {
+            "insert": "expected.files",
+            "documents": [
+              {
+                "_id": "*result",
+                "length": 1,
+                "chunkSize": 4,
+                "uploadDate": "*actual",
+                "md5": "47ed733b8d10be225eceba344d533586",
+                "filename": "filename",
+                "metadata": {
+                  "x": 1
+                }
+              }
+            ]
+          },
+          {
+            "insert": "expected.chunks",
+            "documents": [
+              {
+                "_id": "*actual",
+                "files_id": "*result",
+                "n": 0,
+                "data": {
+                  "$hex": "11"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -295,6 +295,9 @@ var testFiles =[
 
   // Authentication Tests
   , '/test/functional/authentication_tests.js'
+
+  // GridFS
+  , '/test/functional/gridfs_stream_tests.js'
 ]
 
 // Check if we support es6 generators


### PR DESCRIPTION
@christkv this is an implementation of `uploadFromStream()`, which is probably the trickiest part of the streaming GridFS spec. I'd like to get some feedback from you on any glaring design issues you may see before going forward.

General idea:

* Took JSON from spec repo for tests, see `test/functional/specs/gridfs-upload.json`. Also wrote integration test to make sure this works with file streams.
* The code exposes a `GridFSBucket` object that extends from event emitter. Constructor takes db handle and bucket name. Emits 'error' if an error occurred or 'done' when upload is complete.
* The `uploadFromStream()` function pulls buffers from a stream and appends them to its own buffer of size `chunkSizeBytes` until it's full, then it writes the doc to the `fs.chunks` collection. Once the stream has emitted 'end' and there are no more outstanding inserts, we'll insert the files collection doc.

Questions for you:

* Is it ok to add callback to `uploadFromStream()` params? It's not in the spec but probably the most idiomatic way to do it in node.
* Is it ok to add the tests from the gridfs spec as JSON?